### PR TITLE
apiUtilities.R make base_url and api_version parameters of functions

### DIFF
--- a/R/apiUtilities.R
+++ b/R/apiUtilities.R
@@ -6,13 +6,18 @@
 #' Constructs URL for DATIM API query against specified table without paging.
 #'
 #' @param endpoint Character. DATIM API endpoint to query.
+#' @param base_url string - base url for call (preceds "api/...") e.g. "https://www.datim.org/".
+#' Defaults to the global option baseurl.
+#' @param api_version string - api version for call e.g. "30". Defaults to current production version.
 #'
 #' @return Web-encoded URL for DATIM API query.
 #'
-api_call <- function(endpoint) {
+api_call <- function(endpoint, 
+                     base_url = getOption("baseurl"),
+                     api_version = api_version()) {
 
   URL <- paste0(
-    getOption("baseurl"), "api/", api_version(),
+    base_url, "api/", api_version,
     "/",
     endpoint,
     ".json?paging=false") %>%
@@ -107,14 +112,19 @@ api_get <- function(api_call) {
 #' @param sqlView uid of sqlView table to query.
 #' @param var Variable to substitute into SQL query. Only supply if SQL view is
 #' of type query.
-#'
+#' @param base_url string - base url for call (preceds "api/...") e.g. "https://www.datim.org/".
+#' Defaults to the global option baseurl.
+#' @param api_version string - api version for call e.g. "30". Defaults to current production version.
 #' @return Web-encoded URL for DATIM API query.
 #'
-api_sql_call <- function(sqlView, var = NA) {
+api_sql_call <- function(sqlView, 
+                         var = NA, 
+                         base_url = getOption("baseurl"),
+                         api_version = api_version()) {
 
   URL <-
     paste0(
-      getOption("baseurl"),"api/",api_version(),
+      base_url,"api/", api_version,
       "/sqlViews/",
       sqlView,
       "/data.csv?",

--- a/R/apiUtilities.R
+++ b/R/apiUtilities.R
@@ -14,7 +14,7 @@
 #'
 api_call <- function(endpoint, 
                      base_url = getOption("baseurl"),
-                     api_version = api_version()) {
+                     api_version = prod_version()) {
 
   URL <- paste0(
     base_url, "api/", api_version,
@@ -120,7 +120,7 @@ api_get <- function(api_call) {
 api_sql_call <- function(sqlView, 
                          var = NA, 
                          base_url = getOption("baseurl"),
-                         api_version = api_version()) {
+                         api_version = prod_version()) {
 
   URL <-
     paste0(

--- a/R/api_version.R
+++ b/R/api_version.R
@@ -3,4 +3,4 @@
 #'
 #' @return Version of the DHIS2 API
 #'
-api_version <- function() { "30" }
+prod_version <- function() { "30" }

--- a/R/loginToDATIM.R
+++ b/R/loginToDATIM.R
@@ -57,7 +57,7 @@ ValidateConfig<-function(dhis_config) {
 #'
 DHISLogin<-function(dhis_config) {
 
-  url <- URLencode(URL = paste0(getOption("baseurl"), "api/",api_version(),"/me"))
+  url <- URLencode(URL = paste0(getOption("baseurl"), "api/",prod_version(),"/me"))
   #Logging in here will give us a cookie to reuse
   r <- httr::GET(url ,
                  httr::authenticate(dhis_config$dhis$username, dhis_config$dhis$password),


### PR DESCRIPTION
@jacksonsj 

I discussed with @jason-p-pickering advantages of making base_url a parameter of functions instead of hard coding it in the function itself. We can still use getOption("baseurl") as the default for the parameter, but we give the user the ability to override this default.

Use cases include situations where someone is analyzing data from more than one DATIM instance, writing unit tests that target play.dhis2 and DATIM as appropriate, writing examples that target play.dhis2 even if a user may be logged in to a DATIM instance.  

I think the basics of this argument are true for api_version. Since we are doing little more in the functions than parsing the JSON and returning it, and we saw the JSON structure changed from 2.29 to 2.30 in some cases (sql views I think), I think the the api_version to use should be chosen by the user of the package, not the package. But we can use the current prod version as the default. If for some reason our functions were only valid for certain api versions, then we can document it and trap bad versions. 