### PR TITLE
Get metadata unit tests

### DIFF
--- a/tests/testthat/test-getMetadata.R
+++ b/tests/testthat/test-getMetadata.R
@@ -24,23 +24,25 @@ library(httptest)
     )
    
    
-   test_that(paste0("https://play.dhis2.org/2.33/api/dataElements.json?",
-                    "paging=false&filter=id:eq:D7Ehxtgosna"
+   test_that(paste0("Basic eq call: ",
+                    "https://play.dhis2.org/2.33/api/dataElements.json?",
+                    "paging=false&filter=id:eq:FTRrcoaog83"
                     ), {
      data <- getMetadata(
        end_point = "dataElements",
-       filters = "id:eq:D7Ehxtgosna", 
+       filters = "id:eq:FTRrcoaog83", 
        base_url = "https://play.dhis2.org/2.33/"
      )
      # data <- data[["dataElements"]]
      testthat::expect_s3_class(data, "data.frame")
      testthat::expect_equal(NROW(data), 1)
      testthat::expect_named(data, c("id", "displayName"))
-     testthat::expect_equal(data$id, "D7Ehxtgosna")
+     testthat::expect_equal(data$id, "FTRrcoaog83")
      rm(data)
    })
    
-   test_that(paste0("https://play.dhis2.org/2.33/api/dimensions.json?",
+   test_that(paste0("List Column: ",
+                    "https://play.dhis2.org/2.33/api/dimensions.json?",
                     "paging=false&filter=id:eq:gtuVl6NbXQV",
                     "&fields=items[name,id]"
    ), {
@@ -60,7 +62,8 @@ library(httptest)
      rm(data)
    })
    
-   test_that(paste0("https://play.dhis2.org/2.33/api/dimensions.json?",
+   test_that(paste0("Basic in call: ",
+                    "https://play.dhis2.org/2.33/api/dimensions.json?",
                     "paging=false&filter=id:in:[yY2bQYqNt0o,gtuVl6NbXQV]",
                     "&fields=items[name,id]"
                     ), {
@@ -80,7 +83,8 @@ library(httptest)
      rm(data)
    })
   
-   test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnitGroups.json?",
+   test_that(paste0("No Filter: ", 
+                    "https://play.dhis2.org/2.33/api/organisationUnitGroups.json?",
                     "paging=false"), {
      data <- getMetadata(
        end_point = "organisationUnitGroups", 
@@ -91,7 +95,8 @@ library(httptest)
      rm(data)
    })
    
-   test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
+   test_that(paste0("Filter with path: ", 
+                    "https://play.dhis2.org/2.33/api/organisationUnits.json?",
                     "paging=false",
                     "&filter=organisationUnitGroups.id:eq:RpbiCJpIYEj",
                     "&fields=id,name,level,ancestors[id,name]"), {
@@ -101,11 +106,13 @@ library(httptest)
                         fields = "id,name,level,ancestors[id,name]",
                         base_url = "https://play.dhis2.org/2.33/"
                       )
+                      # data <- data[["organisationUnits"]]
                       testthat::expect_equal(NROW(data), 1)
                       rm(data)
                     })
    
-   test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
+   test_that(paste0("Two Filters: ", 
+                    "https://play.dhis2.org/2.33/api/organisationUnits.json?",
                     "paging=false",
                     "&filter=organisationUnitGroups.name:eq:District",
                     "&filter=children.id:in:[YuQRtpLP10I,fwH9ipvXde9]"), {
@@ -116,58 +123,62 @@ library(httptest)
                         fields = "id,name,level,ancestors[id,name]",
                         base_url = "https://play.dhis2.org/2.33/"
                       )
+                      # data <- data[["organisationUnits"]]
                       testthat::expect_equal(NROW(data), 2)
                       rm(data)
                     })
    
-   # test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
-   #                  "paging=false&filter=name:like:Baoma"
-   #                  ), {
-   #                    data <- getMetadata(
-   #                      end_point = "organisationUnits",
-   #                      filters = "name:like:Baoma", 
-   #                      base_url = "https://play.dhis2.org/2.33/")
-   #                    
-   #                    # testthat::expect_s3_class(data, "data.frame")
-   #                     testthat::expect_equal(NROW(data), 10)
-   #                    # testthat::expect_named(data, "items")
-   #                    # data <- tidyr::unnest(data, cols = items)
-   #                    # testthat::expect_named(data, c("name", "id"))
-   #                    # testthat::expect_equal(NROW(data), 7)
-   #                    rm(data)
-   # })  
-   # 
-   # test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
-   #                  "paging=false&filter=name:like:Baoma",
-   #                  "&filter=level:eq:3&fields=:all"
-   # ), {
-   #   data <- getMetadata(
-   #     end_point = "organisationUnits",
-   #     filters = c("name:like:Baoma",
-   #                 "level:eq:3"), 
-   #     fields = ":all",
-   #     base_url = "https://play.dhis2.org/2.33/")
-   #   
-   #   # testthat::expect_s3_class(data, "data.frame")
-   #   testthat::expect_equal(NROW(data), 1)
-   #   # testthat::expect_named(data, "items")
-   #   # data <- tidyr::unnest(data, cols = items)
-   #   # testthat::expect_named(data, c("name", "id"))
-   #   # testthat::expect_equal(NROW(data), 7)
-   #   rm(data)
-   # })  
-   
-  # test_that(paste0("https://play.dhis2.org/2.33/api/indicators.json?",
-  #                  "paging=false&filter=id:eq:ReUHfIn0pTQ",
-  #                  "&fields=name,id,numerator,denominator"
-  #                  ), {
-  #                    data <- getMetadata(
-  #                      end_point = "indicators",
-  #                      filters = "id:eq:ReUHfIn0pTQ", 
-  #                      fields = "name,id,numerator,denominator",
-  #                      base_url = "https://play.dhis2.org/2.33/"
-  #                    )
-  #                  })
-  
-  
+   test_that(paste0("String like: ",
+                    "https://play.dhis2.org/2.33/api/organisationUnits.json?",
+                    "paging=false&filter=name:like:Baoma"
+                    ), {
+                      data <- getMetadata(
+                        end_point = "organisationUnits",
+                        filters = "name:like:Baoma",
+                        base_url = "https://play.dhis2.org/2.33/")
+
+                      # testthat::expect_s3_class(data, "data.frame")
+                       testthat::expect_equal(NROW(data), 10)
+                      # testthat::expect_named(data, "items")
+                      # data <- tidyr::unnest(data, cols = items)
+                      # testthat::expect_named(data, c("name", "id"))
+                      # testthat::expect_equal(NROW(data), 7)
+                      rm(data)
+   })
+
+   test_that(paste0("Filter with less common property: ", 
+                    "https://play.dhis2.org/2.33/api/organisationUnits.json?",
+                    "paging=false&filter=name:like:Baoma",
+                    "&filter=level:eq:3&fields=:all"
+   ), {
+     data <- getMetadata(
+       end_point = "organisationUnits",
+       filters = c("name:like:Baoma",
+                   "level:eq:3"),
+       fields = ":all",
+       base_url = "https://play.dhis2.org/2.33/")
+
+     # testthat::expect_s3_class(data, "data.frame")
+     testthat::expect_equal(NROW(data), 1)
+     # testthat::expect_named(data, "items")
+     # data <- tidyr::unnest(data, cols = items)
+     # testthat::expect_named(data, c("name", "id"))
+     # testthat::expect_equal(NROW(data), 7)
+     rm(data)
+   })
+
+  test_that(paste0("Call with indicator endpoint: ",
+                   "https://play.dhis2.org/2.33/api/indicators.json?",
+                   "paging=false&filter=id:eq:ReUHfIn0pTQ",
+                   "&fields=name,id,numerator,denominator"
+                   ), {
+                     data <- getMetadata(
+                       end_point = "indicators",
+                       filters = "id:eq:ReUHfIn0pTQ",
+                       fields = "name,id,numerator,denominator",
+                       base_url = "https://play.dhis2.org/2.33/"
+                     )
+                   })
+
+
 # })

--- a/tests/testthat/test-getMetadata.R
+++ b/tests/testthat/test-getMetadata.R
@@ -1,15 +1,76 @@
-context("make arbitrary api call DATIM")
+context("getMetadata")
 
-with_mock_api({
-  test_that("We can get a metadataresponse", {
-    base_url <- "www.datim.org/"
-    end_point <- "dataElements"
-    filters <- "?filter=id:ilike:B"
-    fields <- "name,id,numerator,denominator,categoryOptions"
-    see <- getMetadata(
-      base_url = base_url, end_point = end_point,
-      filters = filters, fields = fields
+# code to create/update mocks
+library(httptest)
+
+# httptest::start_capturing(simplify = FALSE)
+# httr::content(
+#   httr::GET(
+#     paste0("https://play.dhis2.org/2.33/api/indicators.json?",
+#            "paging=false&filter=id:eq:ReUHfIn0pTQ",
+#            "&fields=name,id,numerator,denominator"
+#            ),
+#     httr::authenticate("admin", "district")
+#     )
+#   )
+# 
+# httptest::stop_capturing()
+
+# with_mock_api({
+
+   httr::GET(
+     paste0("https://play.dhis2.org/2.33/api/me"),
+    httr::authenticate("admin", "district")
     )
-    expect_identical(see$dataElements$id, "sAxSUTFc5tp")
-  })
-})
+   
+   
+   test_that(paste0("https://play.dhis2.org/2.33/api/dataElements.json?",
+                    "paging=false&filter=id:eq:D7Ehxtgosna"
+                    ), {
+     data <- getMetadata(
+       end_point = "dataElements",
+       filters = "id:eq:D7Ehxtgosna", 
+       base_url = "https://play.dhis2.org/2.33/"
+     )
+     #data <- data[["dataElements"]]
+     testthat::expect_s3_class(data, "data.frame")
+     testthat::expect_equal(NROW(data), 1)
+     testthat::expect_named(data, c("id", "displayName"))
+     testthat::expect_equal(data$id, "D7Ehxtgosna")
+     rm(data)
+   })
+   
+   test_that(paste0("https://play.dhis2.org/2.33/api/dimensions.json?",
+                    "paging=false&filter=id:eq:gtuVl6NbXQV",
+                    "&fields=items[name,id]"
+   ), {
+     data <- getMetadata(
+       end_point = "dimensions",
+       filters = "id:eq:gtuVl6NbXQV", 
+       base_url = "https://play.dhis2.org/2.33/",
+       fields = "items[name,id]"
+     )
+     #data <- data[["dimensions"]]
+     testthat::expect_s3_class(data, "data.frame")
+     testthat::expect_equal(NROW(data), 1)
+     testthat::expect_named(data, "items")
+     data <- tidyr::unnest(data, cols = items)
+     testthat::expect_named(data, c("name", "id"))
+     testthat::expect_equal(NROW(data), 3)
+     rm(data)
+   })
+      
+  test_that(paste0("https://play.dhis2.org/2.33/api/indicators.json?",
+                   "paging=false&filter=id:eq:ReUHfIn0pTQ",
+                   "&fields=name,id,numerator,denominator"
+                   ), {
+                     data <- getMetadata(
+                       end_point = "indicators",
+                       filters = "id:eq:ReUHfIn0pTQ", 
+                       fields = "name,id,numerator,denominator",
+                       base_url = "https://play.dhis2.org/2.33/"
+                     )
+                   })
+  
+  
+# })

--- a/tests/testthat/test-getMetadata.R
+++ b/tests/testthat/test-getMetadata.R
@@ -32,7 +32,7 @@ library(httptest)
        filters = "id:eq:D7Ehxtgosna", 
        base_url = "https://play.dhis2.org/2.33/"
      )
-     #data <- data[["dataElements"]]
+     # data <- data[["dataElements"]]
      testthat::expect_s3_class(data, "data.frame")
      testthat::expect_equal(NROW(data), 1)
      testthat::expect_named(data, c("id", "displayName"))
@@ -50,7 +50,7 @@ library(httptest)
        base_url = "https://play.dhis2.org/2.33/",
        fields = "items[name,id]"
      )
-     #data <- data[["dimensions"]]
+     # data <- data[["dimensions"]]
      testthat::expect_s3_class(data, "data.frame")
      testthat::expect_equal(NROW(data), 1)
      testthat::expect_named(data, "items")
@@ -59,18 +59,115 @@ library(httptest)
      testthat::expect_equal(NROW(data), 3)
      rm(data)
    })
-      
-  test_that(paste0("https://play.dhis2.org/2.33/api/indicators.json?",
-                   "paging=false&filter=id:eq:ReUHfIn0pTQ",
-                   "&fields=name,id,numerator,denominator"
-                   ), {
-                     data <- getMetadata(
-                       end_point = "indicators",
-                       filters = "id:eq:ReUHfIn0pTQ", 
-                       fields = "name,id,numerator,denominator",
-                       base_url = "https://play.dhis2.org/2.33/"
-                     )
-                   })
+   
+   test_that(paste0("https://play.dhis2.org/2.33/api/dimensions.json?",
+                    "paging=false&filter=id:in:[yY2bQYqNt0o,gtuVl6NbXQV]",
+                    "&fields=items[name,id]"
+                    ), {
+     data <- getMetadata(
+       end_point = "dimensions",
+       filters = "id:in:[yY2bQYqNt0o,gtuVl6NbXQV]", 
+       base_url = "https://play.dhis2.org/2.33/",
+       fields = "items[name,id]"
+     )
+     # data <- data[["dimensions"]]
+     testthat::expect_s3_class(data, "data.frame")
+     testthat::expect_equal(NROW(data), 2)
+     testthat::expect_named(data, "items")
+     data <- tidyr::unnest(data, cols = items)
+     testthat::expect_named(data, c("name", "id"))
+     testthat::expect_equal(NROW(data), 7)
+     rm(data)
+   })
+  
+   test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnitGroups.json?",
+                    "paging=false"), {
+     data <- getMetadata(
+       end_point = "organisationUnitGroups", 
+       base_url = "https://play.dhis2.org/2.33/"
+     )
+     # data <- data[["organisationUnitGroups"]]
+     testthat::expect_equal(NROW(data), 18)
+     rm(data)
+   })
+   
+   test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
+                    "paging=false",
+                    "&filter=organisationUnitGroups.id:eq:RpbiCJpIYEj",
+                    "&fields=id,name,level,ancestors[id,name]"), {
+                      data <- getMetadata(
+                        end_point = "organisationUnits",
+                        filters = "organisationUnitGroups.id:eq:RpbiCJpIYEj",
+                        fields = "id,name,level,ancestors[id,name]",
+                        base_url = "https://play.dhis2.org/2.33/"
+                      )
+                      testthat::expect_equal(NROW(data), 1)
+                      rm(data)
+                    })
+   
+   test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
+                    "paging=false",
+                    "&filter=organisationUnitGroups.name:eq:District",
+                    "&filter=children.id:in:[YuQRtpLP10I,fwH9ipvXde9]"), {
+                      data <- getMetadata(
+                        end_point = "organisationUnits",
+                        filters = c("organisationUnitGroups.name:eq:District",
+                                    "children.id:in:[YuQRtpLP10I,fwH9ipvXde9]"),
+                        fields = "id,name,level,ancestors[id,name]",
+                        base_url = "https://play.dhis2.org/2.33/"
+                      )
+                      testthat::expect_equal(NROW(data), 2)
+                      rm(data)
+                    })
+   
+   # test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
+   #                  "paging=false&filter=name:like:Baoma"
+   #                  ), {
+   #                    data <- getMetadata(
+   #                      end_point = "organisationUnits",
+   #                      filters = "name:like:Baoma", 
+   #                      base_url = "https://play.dhis2.org/2.33/")
+   #                    
+   #                    # testthat::expect_s3_class(data, "data.frame")
+   #                     testthat::expect_equal(NROW(data), 10)
+   #                    # testthat::expect_named(data, "items")
+   #                    # data <- tidyr::unnest(data, cols = items)
+   #                    # testthat::expect_named(data, c("name", "id"))
+   #                    # testthat::expect_equal(NROW(data), 7)
+   #                    rm(data)
+   # })  
+   # 
+   # test_that(paste0("https://play.dhis2.org/2.33/api/organisationUnits.json?",
+   #                  "paging=false&filter=name:like:Baoma",
+   #                  "&filter=level:eq:3&fields=:all"
+   # ), {
+   #   data <- getMetadata(
+   #     end_point = "organisationUnits",
+   #     filters = c("name:like:Baoma",
+   #                 "level:eq:3"), 
+   #     fields = ":all",
+   #     base_url = "https://play.dhis2.org/2.33/")
+   #   
+   #   # testthat::expect_s3_class(data, "data.frame")
+   #   testthat::expect_equal(NROW(data), 1)
+   #   # testthat::expect_named(data, "items")
+   #   # data <- tidyr::unnest(data, cols = items)
+   #   # testthat::expect_named(data, c("name", "id"))
+   #   # testthat::expect_equal(NROW(data), 7)
+   #   rm(data)
+   # })  
+   
+  # test_that(paste0("https://play.dhis2.org/2.33/api/indicators.json?",
+  #                  "paging=false&filter=id:eq:ReUHfIn0pTQ",
+  #                  "&fields=name,id,numerator,denominator"
+  #                  ), {
+  #                    data <- getMetadata(
+  #                      end_point = "indicators",
+  #                      filters = "id:eq:ReUHfIn0pTQ", 
+  #                      fields = "name,id,numerator,denominator",
+  #                      base_url = "https://play.dhis2.org/2.33/"
+  #                    )
+  #                  })
   
   
 # })


### PR DESCRIPTION
@maxwellchandler 

This PR includes a number of tests for getMetadata. Each of these represents a case of one or more real metadata calls from data pack or datapack commons outlined in https://github.com/pepfar-datim/COP-Target-Setting/issues/733.

Some reasons the tests are not passing seem to be

1) not retuning a data frame that peels off the endpoint by default. I see that there is a wrapper reduce parameter, but we should always automatically peel off at least the api endpoint by default.  
2) issues with filters that reach into a collection for instance `organisationUnits.id:eq:uid11111111`
3) difficulties with filters for less common properties e.g. level:eq:3
4) I cannot seem to call the `indicators` endpoint. I suspect an issue with a regex statement picking up on the `in` in `indicators` 

Note I do not have mocks set up yet so these tests make live calls to play.dhis2.org