### PR TITLE
Update getMetadata.R stop changing eq to in

### DIFF
--- a/R/getMetadata.R
+++ b/R/getMetadata.R
@@ -89,27 +89,17 @@ processFilters <- function(end_point, filters) {
   
   #if the format comes in correct
   if(stringr::str_count(look, pattern = ":") == 2){
-    filter_option_orig <- stringr::str_extract(look, '(?<=:).*(?=:)')    
+    filter_option <- stringr::str_extract(look, '(?<=:).*(?=:)')    
     filter_item <- stringr::str_extract(look, '^[^:]*')
     rest <- stringr::str_extract(look, '[^:]+$')
     end_point <- ifelse(is.na(end_point), "", end_point)
     end_point_tentative = ""
     
-    
-    # this block replaces the filter with one more adequate (eq=in, like=ilike, etc.)
-    if (grepl("eq", filter_option_orig)) {
-      filter_option <- sub("eq", "in", filter_option_orig)
-    } else {
-      filter_option <- filter_option_orig
-    }
-    
     # creates a basic filter path
-    ex <- 
-      gsub(filter_option_orig, filter_option, paste0(filter_item,
-                                                     filter_option_orig,
-                                                     rest))
-    
-  } else{
+    ex <- paste0(filter_item,
+                 filter_option,
+                 rest)
+    } else{
   
   # extracts end_point and what is not end_point
   end_point_tentative <- stringr::str_extract(look, ".+?(?=id|name)")


### PR DESCRIPTION
@maxwellchandler I started adding mocks for the getMetadata tests and I noticed that `eq` was being converted to `in` in the filters. I don't think this is necessary in the getMetadata function and this PR removes that code. This pull request will merge with the branch that has the mocks included. All tests are passing with the mocks I set up after this change.

For higher level function such as getOrgUnits("uid11111111") even though there is only 1 uid it is fine to use the `in` operator, this is really just to simplify the code in getOrgUnits. We can have in as the default operator for these high level helpers and don't need to convert it to eq if there is only one value paswed to the function.

Technically id:in:[uid11111111] and id:eq:uid11111111 are 100% equivalent, but the code to convert from eq to in in getMetadata does not add value/functionality.