### PR TITLE
Additional error handling and unit tests for metadata filter formaters

### DIFF
--- a/R/getMetadata.R
+++ b/R/getMetadata.R
@@ -330,7 +330,24 @@ getMetadata <- function(end_point,
 #' property %d!in% values
 
 metadataFilter <- function(values, property, operator) {
-  if (length(values) > 1) {
+  
+  # check values is a vector only for in and !in operators 
+  if (length(values) > 1 &&
+      !(operator %in% c("in", "!in"))) {
+    stop("A vector of values is only supported for in and !in operators")
+  }
+  
+  if (is.null(values) &&
+      !(operator %in% c("null", "!null", "empty"))) {
+    stop("NULL values are only supported for null, !null and empty operators")
+  }
+  
+  if (!is.null(values) &&
+      operator %in% c("null", "!null", "empty")) {
+    stop("NULL values required for null, !null and empty operators")
+  }
+  
+  if (operator %in% c("in", "!in")) {
     return(paste0(
       property, ":", operator, ":[",
       paste0(values, collapse = ","),

--- a/tests/testthat/test-getMetadata.R
+++ b/tests/testthat/test-getMetadata.R
@@ -252,7 +252,7 @@ with_mock_api({
 # httr::content(httr::GET(paste0(
 #   "https://play.dhis2.org/2.33/api/organisationUnitGroups.json?",
 #   "paging=false&fields=name,id")))
-    
+  
     data <- getMetadata(
       end_point = "organisationUnitGroups",
       base_url = "https://play.dhis2.org/2.33/"
@@ -313,11 +313,11 @@ with_mock_api({
   })
 
   test_that("String like: ", {
-    
+
 # httr::content(httr::GET(paste0(
 #   "https://play.dhis2.org/2.33/api/organisationUnits.json?",
 #   "paging=false&filter=name:like:Baoma&fields=name,id")))
-    
+
     data <- getMetadata(
       end_point = "organisationUnits",
       name %dlike% "Baoma",
@@ -328,7 +328,7 @@ with_mock_api({
   })
 
   test_that("URL encoding: ",{
-    
+
 # httr::content(httr::GET(paste0(
 #   "https://play.dhis2.org/2.33/api/organisationUnits.json?",
 #   "paging=false&filter=name:like:Sierra%20Leone&fields=name,id")))
@@ -367,7 +367,6 @@ with_mock_api({
     rm(data)
   })
 
-
   test_that(paste0(
     "Call with indicator endpoint: ",
     "https://play.dhis2.org/2.33/api/indicators.json?",
@@ -387,4 +386,59 @@ with_mock_api({
       "numerator", "denominator"
     ))
   })
-})
+
+  test_that("Metadata filter format helpers", {
+
+# standard call
+    expect_identical(metadataFilter("V", "P", "O"),
+                     "P:O:V")
+
+# value null if and only if operator is null, !null or empty
+    expect_identical(metadataFilter(NULL, "P", "null"),
+                     "P:null:")
+    expect_identical(metadataFilter(NULL, "P", "!null"),
+                     "P:!null:")
+    expect_identical(metadataFilter(NULL, "P", "empty"),
+                     "P:empty:")
+    expect_error(metadataFilter("V", "P", "null"))
+    expect_error(metadataFilter("V", "P", "!null"))
+    expect_error(metadataFilter("V", "P", "empty"))
+    expect_error(metadataFilter(NULL, "P", "O"))
+
+# values can have length > 1 only if operator is in or !in
+# and values for in and !in always enclosed in square brackets
+    expect_identical(metadataFilter(c(1, 2), "P", "in"),
+                     "P:in:[1,2]")
+    expect_identical(metadataFilter(c("1", "2"), "P", "!in"),
+                     "P:!in:[1,2]")
+    expect_identical(metadataFilter(1, "P", "in"),
+                     "P:in:[1]")
+    expect_identical(metadataFilter("2", "P", "!in"),
+                     "P:!in:[2]")
+    expect_error(metadataFilter(c("1", "2"), "P", "O"))
+
+# standard and non standard eval
+    expect_identical(id %deq% "V",
+                     "id" %deq% "V")
+    expect_identical(id %din% c("V1", "V2"),
+                     "id" %din% c("V1", "V2"))
+
+# %din% and %!din%
+    expect_identical(P %din% "V",
+                     "P:in:[V]")
+    expect_identical(P %d!in% "V",
+                     "P:!in:[V]")
+    expect_identical(P %din% c("V_1", "V_2"),
+                     "P:in:[V_1,V_2]")
+    expect_identical(P %d!in% c("V_1", "V_2"),
+                     "P:!in:[V_1,V_2]")
+
+# %deq% and %d!eq%
+    expect_identical(P %deq% "V", "P:eq:V")
+    expect_identical(P %d!eq% "V", "P:!eq:V")
+
+# %dlike% and %d!like%
+    expect_identical(P %dlike% "V", "P:like:V")
+    expect_identical(P %d!like% "V", "P:!like:V")
+    })
+  })

--- a/tests/testthat/test-getMetadata.R
+++ b/tests/testthat/test-getMetadata.R
@@ -126,11 +126,11 @@ library(httptest)
 
 with_mock_api({
   test_that("Basic eq call: ", {
-  
+
 # httr::content(httr::GET(paste0(
 #   "https://play.dhis2.org/2.33/api/dataElements.json?",
 #   "paging=false&filter=id:eq:FTRrcoaog83&fields=name,id")))
-    
+  
     data <- getMetadata(
       end_point = "dataElements",
       id %deq% "FTRrcoaog83",
@@ -252,7 +252,7 @@ with_mock_api({
 # httr::content(httr::GET(paste0(
 #   "https://play.dhis2.org/2.33/api/organisationUnitGroups.json?",
 #   "paging=false&fields=name,id")))
-  
+
     data <- getMetadata(
       end_point = "organisationUnitGroups",
       base_url = "https://play.dhis2.org/2.33/"
@@ -327,7 +327,7 @@ with_mock_api({
     rm(data)
   })
 
-  test_that("URL encoding: ",{
+  test_that("URL encoding: ", {
 
 # httr::content(httr::GET(paste0(
 #   "https://play.dhis2.org/2.33/api/organisationUnits.json?",


### PR DESCRIPTION
Adds errors if 1) vector of values provided to operator other than in and !in, 2) NULL value provided if and only if operator not null,!null, or empty.

Makes sure singlular value is encolsed in [] for in and !in operators