### PR TITLE
Dyn get

### DIFF
--- a/R/getAnalytics.R
+++ b/R/getAnalytics.R
@@ -29,7 +29,7 @@ getAnalytics <-  function(...,
                           co = NULL, co_f = NULL,
                           ao = NULL, ao_f = NULL,
                           return_names = F,
-                          d2_session = parent.frame()$d2_default_session,
+                          d2_session = dynGet("d2_default_session", inherits = TRUE),
                           retry = 1){
   #variable set up
   dx <- .dForm(dx, id = "dx");dx_f <- .fForm(dx_f, id = "dx")

--- a/R/getMetadata.R
+++ b/R/getMetadata.R
@@ -86,7 +86,8 @@ getMetadata <- function(end_point,
                         ...,
                         fields = "name,id",
                         as_vector = T,
-                        d2_session = parent.frame()$d2_default_session,
+                        d2_session = dynGet("d2_default_session",
+                                            inherits = TRUE),
                         retry = 1,
                         timeout = 180) {
   if (!is.character(fields)) {

--- a/R/getMetadataEndpoint.R
+++ b/R/getMetadataEndpoint.R
@@ -100,7 +100,7 @@ duplicateResponse <- function(resp, expand, by) {
 .getMetadataEndpoint <- function(end_point, values,
                                  by = "id",
                                  fields = NULL,
-                                 d2_session = parent.frame()$d2_default_session, retry = 1) {
+                                 d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   see <- try(stringr::str_extract_all(fields, "\\[[^()]+\\]")[[1]], silent = T)
 
   name_reduce <- NULL
@@ -217,7 +217,7 @@ duplicateResponse <- function(resp, expand, by) {
 getCategories <- function(values,
                           by = "id",
                           fields = NULL,
-                          d2_session = parent.frame()$d2_default_session, retry = 1) {
+                          d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("categories",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -231,7 +231,7 @@ getCategories <- function(values,
 getCatCombos <- function(values,
                          by = "id",
                          fields = NULL,
-                         d2_session = parent.frame()$d2_default_session, retry = 1) {
+                         d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("categoryCombos",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -245,7 +245,7 @@ getCatCombos <- function(values,
 getCatOptionCombos <- function(values,
                                by = "id",
                                fields = NULL,
-                               d2_session = parent.frame()$d2_default_session, retry = 1) {
+                               d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("categoryOptionCombos",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -259,7 +259,7 @@ getCatOptionCombos <- function(values,
 getCatOptionGroupSets <- function(values,
                                   by = "id",
                                   fields = NULL,
-                                  d2_session = parent.frame()$d2_default_session, retry = 1) {
+                                  d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("categoryOptionGroupSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -273,7 +273,7 @@ getCatOptionGroupSets <- function(values,
 getCatOptionGroups <- function(values,
                                by = "id",
                                fields = NULL,
-                               d2_session = parent.frame()$d2_default_session, retry = 1) {
+                               d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("categoryOptionGroups",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -287,7 +287,7 @@ getCatOptionGroups <- function(values,
 getCatOptions <- function(values,
                           by = "id",
                           fields = NULL,
-                          d2_session = parent.frame()$d2_default_session, retry = 1) {
+                          d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("categoryOptions",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -301,7 +301,7 @@ getCatOptions <- function(values,
 getDataElementGroupSets <- function(values,
                                     by = "id",
                                     fields = NULL,
-                                    d2_session = parent.frame()$d2_default_session, retry = 1) {
+                                    d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("dataElementGroupSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -315,7 +315,7 @@ getDataElementGroupSets <- function(values,
 getDataElementGroups <- function(values,
                                  by = "id",
                                  fields = NULL,
-                                 d2_session = parent.frame()$d2_default_session, retry = 1) {
+                                 d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("dataElementGroups",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -329,7 +329,7 @@ getDataElementGroups <- function(values,
 getDataElements <- function(values,
                             by = "id",
                             fields = NULL,
-                            d2_session = parent.frame()$d2_default_session, retry = 1) {
+                            d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("dataElements",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -343,7 +343,7 @@ getDataElements <- function(values,
 getDataSets <- function(values,
                         by = "id",
                         fields = NULL,
-                        d2_session = parent.frame()$d2_default_session, retry = 1) {
+                        d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("dataSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -357,7 +357,7 @@ getDataSets <- function(values,
 getIndicatorGroupSets <- function(values,
                                   by = "id",
                                   fields = NULL,
-                                  d2_session = parent.frame()$d2_default_session, retry = 1) {
+                                  d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("indicatorGroupSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -371,7 +371,7 @@ getIndicatorGroupSets <- function(values,
 getIndicatorGroups <- function(values,
                                by = "id",
                                fields = NULL,
-                               d2_session = parent.frame()$d2_default_session, retry = 1) {
+                               d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("indicatorGroups",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -385,7 +385,7 @@ getIndicatorGroups <- function(values,
 getIndicators <- function(values,
                           by = "id",
                           fields = NULL,
-                          d2_session = parent.frame()$d2_default_session, retry = 1) {
+                          d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("indicators",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -399,7 +399,7 @@ getIndicators <- function(values,
 getOptionGroupSets <- function(values,
                                by = "id",
                                fields = NULL,
-                               d2_session = parent.frame()$d2_default_session, retry = 1) {
+                               d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("optionGroupSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -413,7 +413,7 @@ getOptionGroupSets <- function(values,
 getOptionGroups <- function(values,
                             by = "id",
                             fields = NULL,
-                            d2_session = parent.frame()$d2_default_session, retry = 1) {
+                            d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("optionGroups",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -427,7 +427,7 @@ getOptionGroups <- function(values,
 getOptionSets <- function(values,
                           by = "id",
                           fields = NULL,
-                          d2_session = parent.frame()$d2_default_session, retry = 1) {
+                          d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("optionSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -441,7 +441,7 @@ getOptionSets <- function(values,
 getOptions <- function(values,
                        by = "id",
                        fields = NULL,
-                       d2_session = parent.frame()$d2_default_session, retry = 1) {
+                       d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("options",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -455,7 +455,7 @@ getOptions <- function(values,
 getOrgUnitGroupSets <- function(values,
                                 by = "id",
                                 fields = NULL,
-                                d2_session = parent.frame()$d2_default_session, retry = 1) {
+                                d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("organisationUnitGroupSets",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -469,7 +469,7 @@ getOrgUnitGroupSets <- function(values,
 getOrgUnitGroups <- function(values,
                              by = "id",
                              fields = NULL,
-                             d2_session = parent.frame()$d2_default_session, retry = 1) {
+                             d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("organisationUnitGroups",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -483,7 +483,7 @@ getOrgUnitGroups <- function(values,
 getOrgUnits <- function(values,
                         by = "id",
                         fields = NULL,
-                        d2_session = parent.frame()$d2_default_session, retry = 1) {
+                        d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("organisationUnits",
                        values = values,
                        by = as.character(rlang::ensym(by)),
@@ -497,7 +497,7 @@ getOrgUnits <- function(values,
 getDimensions <- function(values,
                           by = "id",
                           fields = NULL,
-                          d2_session = parent.frame()$d2_default_session, retry = 1) {
+                          d2_session = dynGet("d2_default_session", inherits = TRUE), retry = 1) {
   .getMetadataEndpoint("dimensions",
                        values = values,
                        by = as.character(rlang::ensym(by)),

--- a/R/loginToDATIM.R
+++ b/R/loginToDATIM.R
@@ -119,12 +119,15 @@ getCredentialsFromKeyring <- function(ring) {
 #' connecting to datim. Generally a custom name should only be needed if you need to log into
 #' two seperate DHIS2 instances at the same time. If you create a d2Session object with a
 #' custom name then this object must be passed to other datimutils functions explicitly
+#' @param d2_session_envir the environment in which to place the R6 login object, default
+#' is the immediate calling environment
 loginToDATIM <- function(config_path = NULL,
                          config_path_level = "dhis",
                          username = NULL,
                          password = NULL,
                          base_url = NULL,
-                         d2_session_name = "d2_default_session") {
+                         d2_session_name = "d2_default_session",
+                         d2_session_envir = parent.frame()) {
 
   if((!(is.null(username)) && is.null(password)) || (is.null(username) && !(is.null(password)))){
     stop("If directly providing function credentials you must specify both username and password")
@@ -192,6 +195,6 @@ loginToDATIM <- function(config_path = NULL,
                          base_url = base_url,
                          handle = handle,
                          me = me), 
-           envir = parent.frame())
+           envir = d2_session_envir)
   }
 }

--- a/man/dot-getMetadataEndpoint.Rd
+++ b/man/dot-getMetadataEndpoint.Rd
@@ -73,7 +73,7 @@ getCategories(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -81,7 +81,7 @@ getCatCombos(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -89,7 +89,7 @@ getCatOptionCombos(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -97,7 +97,7 @@ getCatOptionGroupSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -105,7 +105,7 @@ getCatOptionGroups(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -113,7 +113,7 @@ getCatOptions(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -121,7 +121,7 @@ getDataElementGroupSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -129,7 +129,7 @@ getDataElementGroups(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -137,7 +137,7 @@ getDataElements(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -145,7 +145,7 @@ getDataSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -153,7 +153,7 @@ getIndicatorGroupSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -161,7 +161,7 @@ getIndicatorGroups(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -169,7 +169,7 @@ getIndicators(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -177,7 +177,7 @@ getOptionGroupSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -185,7 +185,7 @@ getOptionGroups(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -193,7 +193,7 @@ getOptionSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -201,7 +201,7 @@ getOptions(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -209,7 +209,7 @@ getOrgUnitGroupSets(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -217,7 +217,7 @@ getOrgUnitGroups(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -225,7 +225,7 @@ getOrgUnits(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 
@@ -233,7 +233,7 @@ getDimensions(
   values,
   by = "id",
   fields = NULL,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 }

--- a/man/getAnalytics.Rd
+++ b/man/getAnalytics.Rd
@@ -17,7 +17,7 @@ getAnalytics(
   ao = NULL,
   ao_f = NULL,
   return_names = F,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1
 )
 }

--- a/man/getMetadata.Rd
+++ b/man/getMetadata.Rd
@@ -9,7 +9,7 @@ getMetadata(
   ...,
   fields = "name,id",
   as_vector = T,
-  d2_session = parent.frame()$d2_default_session,
+  d2_session = dynGet("d2_default_session", inherits = TRUE),
   retry = 1,
   timeout = 180
 )

--- a/man/loginToDATIM.Rd
+++ b/man/loginToDATIM.Rd
@@ -11,7 +11,8 @@ loginToDATIM(
   username = NULL,
   password = NULL,
   base_url = NULL,
-  d2_session_name = "d2_default_session"
+  d2_session_name = "d2_default_session",
+  d2_session_envir = parent.frame()
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ name is d2_default_session and will be used by other datimutils functions by def
 connecting to datim. Generally a custom name should only be needed if you need to log into
 two seperate DHIS2 instances at the same time. If you create a d2Session object with a
 custom name then this object must be passed to other datimutils functions explicitly}
+
+\item{d2_session_envir}{the environment in which to place the R6 login object, default
+is the immediate calling environment}
 }
 \description{
 logins into a datim or dhis2 api using either default keyring and 


### PR DESCRIPTION
@maxwellchandler 

These changes allow us to get the d2_default_session object from higher in the calling stack (up to global environment) than just the parent. I am already running into problem with datapackr isf we just look in the calling parent.

Please give this a desk check and then merge it if you don't see any problems.