### PR TITLE
Hotfix api get retry bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datimutils
 Type: Package
 Title: Utilities for interacting with the DATIM api from R
-Version: 0.3.1
-Date: 2022-07-05
+Version: 0.3.2
+Date: 2022-07-08
 Authors@R: 
     c(
     person("Scott", "Jackson", email = "sjackson@baosystems.com",

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -87,9 +87,10 @@ api_get <- function(path,
     response_code <- httr::status_code(resp)
     Sys.sleep(i - 1)
     i <- i + 1
-    if (response_code == 200 &&
-       resp$url == url &&
-       httr::http_type(resp) == "application/json")
+    if (response_code == 200L && 
+        stringr::str_remove(resp$url, ".*/api/") ==
+        stringr::str_remove(url,  ".*/api/") &&
+        httr::http_type(resp) == "application/json")
     {
       break
     }

--- a/tests/testthat/test-api_get.R
+++ b/tests/testthat/test-api_get.R
@@ -115,7 +115,7 @@ httptest::with_mock_api({
       ))
       testthat::expect_error(
         # httr::GET("http://httpstat.us/504")
-        api_get(path = "504",
+        api_get(path = "504", retry = 2,
                 d2_session = list(base_url = "http://httpstat.us/")))
   })
 


### PR DESCRIPTION
Resolve issue with api_get repeating calls with retry >1 in the case of a base url redirect. The calls were not failing, but they were being repeated unnecessarily due to the check for consistent url in the call and response.