### PR TITLE
Update callDATIMapi.R

### DIFF
--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -82,8 +82,17 @@ api_get <- function(path,
   response_code <- 5
 
   while (i <= retry & (response_code < 400 | response_code >= 500)) {
-    resp <- httr::GET(url, httr::timeout(timeout),
+    resp <- NULL
+    resp <- 
+      try(
+      httr::GET(url, httr::timeout(timeout),
                       handle = handle)
+      )
+    
+    if(is.null(resp)) {
+      next
+    }
+    
     response_code <- httr::status_code(resp)
     Sys.sleep(i - 1)
     i <- i + 1


### PR DESCRIPTION
- Added a try to encapsulate any timeout errors. Was receiving a timeout error prior to this change for some api calls when running `getAnalytics` for data-pack-commons.
- Because timeout error was not an `httr` response `api_get` was not actually handling the error.
- error now forces a retry and caching on datim side resolves timeout error.


