### PR TITLE
Hotfix api_get

### DIFF
--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -96,7 +96,7 @@ api_get <- function(path,
                       handle = handle)
       )
 
-    if (is.null(resp) & class(resp) != "try-error") {
+    if (is.null(resp) | class(resp) != "try-error") {
       next
     }
 

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -96,8 +96,10 @@ api_get <- function(path,
                       handle = handle)
       )
 
-    if (is.null(resp) | class(resp) != "try-error") {
+    if (is.null(resp)) {
       next
+    } else if (class(resp) == "try-error") {
+      stop("There is an issue with the API, try again.")
     }
 
     response_code <- httr::status_code(resp)

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -87,18 +87,15 @@ api_get <- function(path,
   # retry api get block, only retries if response code not in 400s
   i <- 1
   response_code <- 5
-
-  while (i <= retry && (response_code < 400 || response_code >= 500)) {
-    resp <- NULL
+  resp <- "try-error"
+  
+  while (i <= retry && (resp == "try-error"|| response_code < 400 || response_code >= 500)) {
+    #resp <- NULL
     resp <-
       try(
       httr::GET(url, httr::timeout(timeout),
                       handle = handle)
       )
-
-    if (is.null(resp) && class(resp) != "try-error") {
-      next
-    } 
 
     response_code <- httr::status_code(resp)
     Sys.sleep(i - 1)

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -87,19 +87,20 @@ api_get <- function(path,
   # retry api get block, only retries if response code not in 400s
   i <- 1
   response_code <- 5
-  resp <- "try-error"
   
-  while (i <= retry && (resp == "try-error"|| response_code < 400 || response_code >= 500)) {
-    #resp <- NULL
+  while (i <= retry && (response_code < 400 || response_code >= 500)) {
+    resp <- NULL
     resp <-
       try(
       httr::GET(url, httr::timeout(timeout),
                       handle = handle)
       )
 
-    response_code <- httr::status_code(resp)
+    # try is added in order to handle if resp comes back as a "try-error" class
+    response_code <- try(httr::status_code(resp))
     Sys.sleep(i - 1)
     i <- i + 1
+    
     if (response_code == 200L &&
         stringi::stri_replace(resp$url, regex = ".*/api/", replacement = "") ==
         stringi::stri_replace(url, regex = ".*/api/", replacement = "") &&
@@ -107,6 +108,17 @@ api_get <- function(path,
       break
     }
 
+  }
+  
+  # let user know that by the last attempt the api continues to return an error, this should break before status code
+  # as a status code cannot be pulled from a failed api grab
+  if(class(resp) == "try-error") {
+    stop(
+      paste0(
+        "response error, server returned no response even on the last retry, this could a malformed link or a server issue, otherwise try again ",
+        url
+      )
+    )
   }
 
   # unknown error catching which returns message and response code

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -96,7 +96,7 @@ api_get <- function(path,
                       handle = handle)
       )
 
-    if (is.null(resp)) {
+    if (is.null(resp) & class(resp) != "try-error") {
       next
     }
 

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -98,6 +98,17 @@ api_get <- function(path,
 
     # try is added in order to handle if resp comes back as a "try-error" class
     response_code <- try(httr::status_code(resp))
+    
+    if(is(response_code, "try-error")) {
+      message(
+        paste0(
+          "api call to server failed on attempt ",
+          i,
+          " trying again ..."
+        )
+        )
+    }
+    
     Sys.sleep(i - 1)
     i <- i + 1
     

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -87,7 +87,7 @@ api_get <- function(path,
   # retry api get block, only retries if response code not in 400s
   i <- 1
   response_code <- 5
-  
+
   while (i <= retry && (response_code < 400 || response_code >= 500)) {
     resp <- NULL
     resp <-
@@ -97,21 +97,21 @@ api_get <- function(path,
       )
 
     # try is added in order to handle if resp comes back as a "try-error" class
-    response_code <- try(httr::status_code(resp))
-    
-    if(is(response_code, "try-error")) {
+    response_code <- try(httr::status_code(resp), silent = TRUE)
+
+    if (is(response_code, "try-error")) {
       message(
         paste0(
-          "api call to server failed on attempt ",
+          "Api call to server failed on attempt ",
           i,
           " trying again ..."
         )
         )
     }
-    
+
     Sys.sleep(i - 1)
     i <- i + 1
-    
+
     if (response_code == 200L &&
         stringi::stri_replace(resp$url, regex = ".*/api/", replacement = "") ==
         stringi::stri_replace(url, regex = ".*/api/", replacement = "") &&
@@ -120,13 +120,14 @@ api_get <- function(path,
     }
 
   }
-  
+
   # let user know that by the last attempt the api continues to return an error, this should break before status code
   # as a status code cannot be pulled from a failed api grab
-  if(class(resp) == "try-error") {
+  if (class(resp) == "try-error") {
     stop(
       paste0(
-        "response error, server returned no response even on the last retry, this could a malformed link or a server issue, otherwise try again ",
+        "Server returned no response even on the last retry,
+        this could a malformed link or a server issue, otherwise try again ",
         url
       )
     )

--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -84,7 +84,7 @@ api_get <- function(path,
     print(url)
   }
 
-  # retry api get block, only retries if reponse code not in 400s
+  # retry api get block, only retries if response code not in 400s
   i <- 1
   response_code <- 5
 
@@ -96,11 +96,9 @@ api_get <- function(path,
                       handle = handle)
       )
 
-    if (is.null(resp)) {
+    if (is.null(resp) && class(resp) != "try-error") {
       next
-    } else if (class(resp) == "try-error") {
-      stop("There is an issue with the API, try again.")
-    }
+    } 
 
     response_code <- httr::status_code(resp)
     Sys.sleep(i - 1)


### PR DESCRIPTION
Description

This is meant to be a fix for the timeout error we thought that this [PR](https://github.com/pepfar-datim/datimutils/pull/96) fixed, ticket has been created for it [here](https://jira.pepfar.net/browse/DP-769). Unfortunately I continued to see errors -- the reason for this inconsistency is that these timeout errors are not always constant but sometimes random. I have however fixed the issue with this PR and am proposing a hotfix merge.

Fix
1. the fix gets rid of the `next` line of code which wasn't executing properly. 
2. instead we wrap the `resp` object in a `try` statement when attempting to execute `status_code` and add a message to alert the user that the api call failed at which attempt without stopping the execution.
3. this allows the original while loop to run without issue
4. in addition we add another error handling message below the while loop block that stops continuous execution if for some reason after all the retries, resp continues to be an error object 

