### PR TITLE
Dp 781

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datimutils
 Type: Package
 Title: Utilities for interacting with the DATIM api from R
-Version: 0.5.2
-Date: 2022-08-18
+Version: 0.5.3
+Date: 2022-09-08
 Authors@R: 
     c(
     person("Scott", "Jackson", email = "sjackson@baosystems.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# datimutils 0.5.3
+
+## Bug fixes
+* Fixes error conditions in getDataValueSets.
+
 # datimutils 0.5.2
 
 ## Bug fixes

--- a/R/getDataValueSets.R
+++ b/R/getDataValueSets.R
@@ -38,7 +38,7 @@ getDataValueSets <- function(variable_keys = NULL, #keys,
   # The following constraints apply to the data value sets resource:
 
   #1 At least one data set must be specified OR a dataElementGroup.
-  if (!(is.element("dataSet", variable_keys)) == TRUE &
+  if (!(is.element("dataSet", variable_keys)) == TRUE &&
       !(is.element("dataElementGroup", variable_keys)) == TRUE) {
     stop("At least one data set must be specified.")
   }
@@ -55,7 +55,7 @@ getDataValueSets <- function(variable_keys = NULL, #keys,
   }
 
   #3 At least one organisation unit must be specified.
-  if (!(is.element("orgUnit", variable_keys)) == TRUE &
+  if (!(is.element("orgUnit", variable_keys)) == TRUE &&
       !(is.element("orgUnitGroup", variable_keys)) == TRUE) {
     stop("At least one organisation unit must be specified.")
   }

--- a/R/getDataValueSets.R
+++ b/R/getDataValueSets.R
@@ -37,8 +37,9 @@ getDataValueSets <- function(variable_keys = NULL, #keys,
   #Requirements
   # The following constraints apply to the data value sets resource:
 
-  #1 At least one data set must be specified.
-  if (!(is.element("dataSet", variable_keys))) {
+  #1 At least one data set must be specified OR a dataElementGroup.
+  if (!(is.element("dataSet", variable_keys)) == TRUE &
+      !(is.element("dataElementGroup", variable_keys)) == TRUE) {
     stop("At least one data set must be specified.")
   }
 
@@ -54,7 +55,8 @@ getDataValueSets <- function(variable_keys = NULL, #keys,
   }
 
   #3 At least one organisation unit must be specified.
-  if (!(is.element("orgUnit", variable_keys))) {
+  if (!(is.element("orgUnit", variable_keys)) == TRUE &
+      !(is.element("orgUnitGroup", variable_keys)) == TRUE) {
     stop("At least one organisation unit must be specified.")
   }
 

--- a/R/getDataValueSets.R
+++ b/R/getDataValueSets.R
@@ -40,7 +40,7 @@ getDataValueSets <- function(variable_keys = NULL, #keys,
   #1 At least one data set must be specified OR a dataElementGroup.
   if (!(is.element("dataSet", variable_keys)) == TRUE &&
       !(is.element("dataElementGroup", variable_keys)) == TRUE) {
-    stop("At least one data set must be specified.")
+    stop("At least one data set or data element group must be specified.")
   }
 
   #2 Either at least one period or a start date and end date must be specified.
@@ -57,7 +57,7 @@ getDataValueSets <- function(variable_keys = NULL, #keys,
   #3 At least one organisation unit must be specified.
   if (!(is.element("orgUnit", variable_keys)) == TRUE &&
       !(is.element("orgUnitGroup", variable_keys)) == TRUE) {
-    stop("At least one organisation unit must be specified.")
+    stop("At least one organisation unit or organisation unit group must be specified.")
   }
 
   #4 Organisation units must be within the hierarchy of the organisation units

--- a/man/d2Session.Rd
+++ b/man/d2Session.Rd
@@ -32,13 +32,13 @@ with the DHIS2 instance.}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{d2Session$new()}}
-\item \href{#method-clone}{\code{d2Session$clone()}}
+\item \href{#method-d2Session-new}{\code{d2Session$new()}}
+\item \href{#method-d2Session-clone}{\code{d2Session$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-d2Session-new"></a>}}
+\if{latex}{\out{\hypertarget{method-d2Session-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new DHISLogin object
 \subsection{Usage}{
@@ -56,16 +56,13 @@ Create a new DHISLogin object
 connections}
 
 \item{\code{me}}{DHIS2 me response object}
-
-\item{\code{max_cache_age}}{cache expiry currently used
-by datim validation}
 }
 \if{html}{\out{</div>}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-d2Session-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-d2Session-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/tests/testthat/test-getDataValueSets.R
+++ b/tests/testthat/test-getDataValueSets.R
@@ -11,8 +11,8 @@ test_that("GetDataValueSets", {
   #correct file
 
   with_mock_api({
-    data <- getDataValueSets(c("dataSet", "period", "orgUnit"),
-                             c("pBOMPrpg1QX", "202201", "DiszpKrYNg8"),
+    data <- getDataValueSets(variable_keys = c("dataSet", "period", "orgUnit"),
+                             variable_values = c("pBOMPrpg1QX", "202201", "DiszpKrYNg8"),
                              d2_session = play2372)
 
     testthat::expect_named(data, c("dataElement",
@@ -28,8 +28,8 @@ test_that("GetDataValueSets", {
                                    "followup"))
     testthat::expect_equal(NROW(data), 3)
 
-    data2 <- getDataValueSets(c("dataSet", "period", "orgUnit"),
-                              c("pBOMPrpg1QX", "202201", "DiszpKrYNg8"),
+    data2 <- getDataValueSets(variable_keys = c("dataSet", "period", "orgUnit"),
+                              variable_values = c("pBOMPrpg1QX", "202201", "DiszpKrYNg8"),
                               d2_session = play2372,
                               verbose = TRUE)
     testthat::expect_type(data2, "list")
@@ -46,10 +46,20 @@ test_that("GetDataValueSets", {
                                          "followup"))
     testthat::expect_equal(NROW(data2$data), 3)
 
-    testthat::expect_error(getDataValueSets(c("limit"),
-                                            c("3"),
-                                            play2372),
-                           "At least one data set must be specified.",
+    # test missing data set or data element group
+    testthat::expect_error(getDataValueSets(variable_keys = c("limit"),
+                                            variable_values = c("3"),
+                                            d2_session = play2372),
+                           "At least one data set or data element group must be specified.",
                            fixed = TRUE)
+    
+    # test missing orgunit or orgunit group
+    testthat::expect_error(getDataValueSets(variable_keys = c("dataSet", "period"),
+                                            variable_values = c("pBOMPrpg1QX", "202201"),
+                                            d2_session = play2372),
+                           "At least one organisation unit or organisation unit group must be specified.",
+                           fixed = TRUE)
+    
+    
   })
 })

--- a/tests/testthat/test-getDataValueSets.R
+++ b/tests/testthat/test-getDataValueSets.R
@@ -52,14 +52,14 @@ test_that("GetDataValueSets", {
                                             d2_session = play2372),
                            "At least one data set or data element group must be specified.",
                            fixed = TRUE)
-    
+
     # test missing orgunit or orgunit group
     testthat::expect_error(getDataValueSets(variable_keys = c("dataSet", "period"),
                                             variable_values = c("pBOMPrpg1QX", "202201"),
                                             d2_session = play2372),
                            "At least one organisation unit or organisation unit group must be specified.",
                            fixed = TRUE)
-    
-    
+
+
   })
 })


### PR DESCRIPTION
- Since `getDataValueSets`  has been deprecated from `datapackr`, `datimutils::getDataValueSets` was altered to allow passing only a `dataElementGroup` as well as an `orgUnitGroup`
- Now it will require missing both data or org elements to kick the stop error
