### PR TITLE
Simplify api_get

### DIFF
--- a/R/callDATIMapi.R
+++ b/R/callDATIMapi.R
@@ -89,17 +89,18 @@ api_get <- function(path,
   response_code <- 5
 
   while (i <= retry && (response_code < 400 || response_code >= 500)) {
-    resp <- NULL
-    resp <-
-      try(
-      httr::GET(url, httr::timeout(timeout),
+
+    resp <- tryCatch(
+        {
+          httr::GET(url, httr::timeout(timeout),
                       handle = handle)
-      )
+        },
+        error = function(e) {
+          NULL
+        })
+    
 
-    # try is added in order to handle if resp comes back as a "try-error" class
-    response_code <- try(httr::status_code(resp), silent = TRUE)
-
-    if (is(response_code, "try-error")) {
+    if (is.null(resp)) {
       message(
         paste0(
           "Api call to server failed on attempt ",
@@ -123,7 +124,7 @@ api_get <- function(path,
 
   # let user know that by the last attempt the api continues to return an error, this should break before status code
   # as a status code cannot be pulled from a failed api grab
-  if (class(resp) == "try-error") {
+  if (is.null(resp)) {
     stop(
       paste0(
         "Server returned no response even on the last retry,


### PR DESCRIPTION
This is a minor simplification which assigns a response a value of "NULL" if there is an error condition. The API call is retried if an error is caught, similar to the old behavior. 

The previous way this was coded caused some issues when performing unit testing with other packages. Previously, it was clear what the actual URL was which was being called, and we could then figure out what the fixture file name should be. However, everything is now encased in a `try` statement, so it is not clear at all what the actual API call is when performing a test with `with_mock_api`. 

This change should allow us to get the URL when building up a unit test and define the corresponding fixture like this: 

```
> httptest::build_mock_url("https://training.datim.org/api/organisationUnits.json?paging=false&filter=organisationUnitGroups.id:in:[AVy8gJXym2D,mRRlkbZolDR]&filter=ancestors.id:in:[qllxzIjjurr]&fields=id,name,lastUpdated,ancestors[id,name,organisationUnitGroups[id,name]],organisationUnitGroups[id,name]")
[1] "training.datim.org/api/organisationUnits.json-dd4e67"

```