### PR TITLE
Update getMetadataEndpoint.R

### DIFF
--- a/R/getMetadataEndpoint.R
+++ b/R/getMetadataEndpoint.R
@@ -149,7 +149,7 @@ duplicateResponse <- function(resp, expand, by) {
   unique_values <- unique(values)
 
   #break up url to multiple calls if needed
-  if (sum(nchar(unique_values)) > 2000) {
+  if (sum(nchar(unique_values), na.rm = T) > 2000) {
 
     values_list <- .splitUrlComponent(unique_values, 2000)
 


### PR DESCRIPTION
- DP-79
- removes NAs from calculation in `getMetadataEndpoint` so that call does not error out when passing NA values