### PR TITLE
hotfix-dp-973

### DIFF
--- a/R/getAnalytics.R
+++ b/R/getAnalytics.R
@@ -33,7 +33,7 @@ getAnalytics <-  function(...,
                           return_names = FALSE,
                           d2_session = dynGet("d2_default_session", inherits = TRUE),
                           retry = 1,
-                          timeout = 60,
+                          timeout = 180,
                           verbose = FALSE,
                           quiet = TRUE) {
 


### PR DESCRIPTION
This is a hotfix to increase the timeout for getAnalytics.